### PR TITLE
update resourceIdentifier constructors to cover bug in resourcegroups…

### DIFF
--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/ResourceGroupResourceIdentifier.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/ResourceGroupResourceIdentifier.cs
@@ -16,10 +16,11 @@ namespace Azure.ResourceManager.Core
         /// <param name="parent">The <see cref="ResourceGroupResourceIdentifier"/> of the parent of this child resource.</param>
         /// <param name="resourceGroupName">The name of the resourceGroup.</param>
         internal ResourceGroupResourceIdentifier(SubscriptionResourceIdentifier parent, string resourceGroupName)
-            : base(parent, ResourceIdentifier.ResourceGroupsKey, resourceGroupName)
+            : base(parent, ResourceIdentifier.ResourceGroupsType, resourceGroupName)
         {
             if (string.IsNullOrWhiteSpace(resourceGroupName))
                 throw new ArgumentOutOfRangeException(nameof(resourceGroupName), "Invalid resource group name.");
+            IsChild = true;
             ResourceGroupName = resourceGroupName;
         }
 

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/ResourceIdentifier.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/ResourceIdentifier.cs
@@ -24,7 +24,7 @@ namespace Azure.ResourceManager.Core
         internal static ResourceType LocationsType =>
             new ResourceType(BuiltInResourceNamespace, $"{SubscriptionsKey}/{LocationsKey}");
         internal static ResourceType ResourceGroupsType =>
-            new ResourceType(BuiltInResourceNamespace, $"{SubscriptionsKey}/{ResourceGroupsKey}");
+            new ResourceType(BuiltInResourceNamespace, $"{ResourceGroupsKey}");
 
         /// <summary>
         /// The root of the resource hierarchy

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubscriptionResourceIdentifier.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/SubscriptionResourceIdentifier.cs
@@ -35,6 +35,20 @@ namespace Azure.ResourceManager.Core
         /// for resources in the sanem namespace as their parent resource.
         /// </summary>
         /// <param name="parent"> The resource id of the parent resource. </param>
+        /// <param name="resourceType"> The simple type of this resource, for example 'subnets'. </param>
+        /// <param name="resourceName"> The name of this resource. </param>
+        /// <returns> The resource identifier for the given child resource. </returns>
+        internal SubscriptionResourceIdentifier(SubscriptionResourceIdentifier parent, ResourceType resourceType, string resourceName)
+            : base(parent, resourceType, resourceName)
+        {
+            SubscriptionId = parent.SubscriptionId;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SubscriptionResourceIdentifier"/> class 
+        /// for resources in the sanem namespace as their parent resource.
+        /// </summary>
+        /// <param name="parent"> The resource id of the parent resource. </param>
         /// <param name="childResourceType"> The simple type of this resource, for example 'subnets'. </param>
         /// <param name="childResourceName"> The name of this resource. </param>
         /// <returns> The resource identifier for the given child resource. </returns>

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/TenantResourceIdentifier.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/src/Resources/TenantResourceIdentifier.cs
@@ -30,6 +30,19 @@ namespace Azure.ResourceManager.Core
         /// for resources in the same namespace as their parent.
         /// </summary>
         /// <param name="parent"> The parent resource id. </param>
+        /// <param name="resourceType"> The simple type name of the resource without slashes (/), for example 'virtualMachines'.</param>
+        /// <param name="resourceName"> The name of the resource. </param>
+        internal TenantResourceIdentifier(TenantResourceIdentifier parent, ResourceType resourceType, string resourceName)
+            : base(resourceType, resourceName)
+        {
+            Parent = parent;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TenantResourceIdentifier"/> class 
+        /// for resources in the same namespace as their parent.
+        /// </summary>
+        /// <param name="parent"> The parent resource id. </param>
         /// <param name="typeName"> The simple type name of the resource without slashes (/), for example 'virtualMachines'.</param>
         /// <param name="resourceName"> The name of the resource. </param>
         internal TenantResourceIdentifier(TenantResourceIdentifier parent, string typeName, string resourceName)

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/tests/Unit/ResourceIdentifierTests.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/tests/Unit/ResourceIdentifierTests.cs
@@ -153,11 +153,11 @@ namespace Azure.ResourceManager.Core.Tests
         public void CanParseResourceGroups()
         {
             ResourceGroupResourceIdentifier subject = "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg";
-            Assert.AreEqual(subject.ToString(), "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg");
-            Assert.AreEqual(subject.SubscriptionId, "0c2f6471-1bf0-4dda-aec3-cb9272f09575");
-            Assert.AreEqual(subject.ResourceGroupName, "myRg");
-            Assert.AreEqual(subject.ResourceType.Namespace, "Microsoft.Resources");
-            Assert.AreEqual(subject.ResourceType.Type, "subscriptions/resourceGroups");
+            Assert.AreEqual("/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg", subject.ToString());
+            Assert.AreEqual("0c2f6471-1bf0-4dda-aec3-cb9272f09575", subject.SubscriptionId);
+            Assert.AreEqual("myRg", subject.ResourceGroupName);
+            Assert.AreEqual("Microsoft.Resources", subject.ResourceType.Namespace);
+            Assert.AreEqual("resourceGroups", subject.ResourceType.Type);
         }
 
         [TestCase("MyVnet", "MySubnet")]

--- a/sdk/resourcemanager/Azure.ResourceManager.Core/tests/Unit/ResourceIdentifierTests.cs
+++ b/sdk/resourcemanager/Azure.ResourceManager.Core/tests/Unit/ResourceIdentifierTests.cs
@@ -104,12 +104,12 @@ namespace Azure.ResourceManager.Core.Tests
         {
             var resourceId = $"/subscriptions/{subscription}/resourceGroups/{Uri.EscapeDataString(resourceGroup)}/providers/{provider}/{type}/{Uri.EscapeDataString(name)}";
             ResourceGroupResourceIdentifier subject = resourceId;
-            Assert.AreEqual(subject.ToString(), resourceId);
-            Assert.AreEqual(subject.SubscriptionId, subscription);
-            Assert.AreEqual(Uri.UnescapeDataString(subject.ResourceGroupName), resourceGroup);
-            Assert.AreEqual(subject.ResourceType.Namespace, provider);
-            Assert.AreEqual(subject.ResourceType.Type, type);
-            Assert.AreEqual(Uri.UnescapeDataString(subject.Name), name);
+            Assert.AreEqual(resourceId, subject.ToString());
+            Assert.AreEqual(subscription, subject.SubscriptionId);
+            Assert.AreEqual(resourceGroup, Uri.UnescapeDataString(subject.ResourceGroupName));
+            Assert.AreEqual(provider, subject.ResourceType.Namespace);
+            Assert.AreEqual(type, subject.ResourceType.Type);
+            Assert.AreEqual(name, Uri.UnescapeDataString(subject.Name));
         }
 
         [TestCase(TrackedResourceId, "Microsoft.Authorization", "roleAssignments", "myRa")]
@@ -133,20 +133,20 @@ namespace Azure.ResourceManager.Core.Tests
         {
             string id = $"/subscriptions/{subscription}/resourceGroups/{rg}/providers/{resourceNamespace}/{resource}";
             ResourceGroupResourceIdentifier subject = id;
-            Assert.AreEqual(subject.ToString(), id);
-            Assert.AreEqual(subject.SubscriptionId, subscription);
-            Assert.AreEqual(subject.ResourceType.Namespace, resourceNamespace);
-            Assert.AreEqual(subject.ResourceType.Type, type);
+            Assert.AreEqual(id, subject.ToString());
+            Assert.AreEqual(subscription, subject.SubscriptionId);
+            Assert.AreEqual(resourceNamespace, subject.ResourceType.Namespace);
+            Assert.AreEqual(type, subject.ResourceType.Type);
         }
 
         [Test]
         public void CanParseSubscriptions()
         {
             SubscriptionResourceIdentifier subject = "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575";
-            Assert.AreEqual(subject.ToString(), "/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575");
-            Assert.AreEqual(subject.SubscriptionId, "0c2f6471-1bf0-4dda-aec3-cb9272f09575");
-            Assert.AreEqual(subject.ResourceType.Namespace, "Microsoft.Resources");
-            Assert.AreEqual(subject.ResourceType.Type, "subscriptions");
+            Assert.AreEqual("/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575", subject.ToString());
+            Assert.AreEqual("0c2f6471-1bf0-4dda-aec3-cb9272f09575", subject.SubscriptionId);
+            Assert.AreEqual("Microsoft.Resources", subject.ResourceType.Namespace);
+            Assert.AreEqual("subscriptions", subject.ResourceType.Type);
         }
 
         [Test]
@@ -167,23 +167,23 @@ namespace Azure.ResourceManager.Core.Tests
         {
             var resourceId = $"/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg/providers/Microsoft.Network/virtualNetworks/{Uri.EscapeDataString(parentName)}/subnets/{Uri.EscapeDataString(name)}";
             ResourceGroupResourceIdentifier subject = resourceId;
-            Assert.AreEqual(subject.ToString(), resourceId);
-            Assert.AreEqual(subject.SubscriptionId, "0c2f6471-1bf0-4dda-aec3-cb9272f09575");
-            Assert.AreEqual(Uri.UnescapeDataString(subject.ResourceGroupName), "myRg");
-            Assert.AreEqual(subject.ResourceType.Namespace, "Microsoft.Network");
-            Assert.AreEqual(subject.Parent.ResourceType.Type, "virtualNetworks");
-            Assert.AreEqual(subject.ResourceType.Type, "virtualNetworks/subnets");
-            Assert.AreEqual(Uri.UnescapeDataString(subject.Name), name);
+            Assert.AreEqual(resourceId, subject.ToString());
+            Assert.AreEqual("0c2f6471-1bf0-4dda-aec3-cb9272f09575", subject.SubscriptionId);
+            Assert.AreEqual("myRg", Uri.UnescapeDataString(subject.ResourceGroupName));
+            Assert.AreEqual("Microsoft.Network", subject.ResourceType.Namespace);
+            Assert.AreEqual("virtualNetworks", subject.Parent.ResourceType.Type);
+            Assert.AreEqual("virtualNetworks/subnets", subject.ResourceType.Type);
+            Assert.AreEqual(name, Uri.UnescapeDataString(subject.Name));
 
             // check parent type parsing
             ResourceGroupResourceIdentifier parentResource = $"/subscriptions/0c2f6471-1bf0-4dda-aec3-cb9272f09575/resourceGroups/myRg/providers/Microsoft.Network/virtualNetworks/{Uri.EscapeDataString(parentName)}";
-            Assert.AreEqual(subject.Parent, parentResource);
-            Assert.AreEqual(subject.Parent.ToString(), parentResource.ToString());
-            Assert.AreEqual(((ResourceGroupResourceIdentifier)subject.Parent).SubscriptionId, "0c2f6471-1bf0-4dda-aec3-cb9272f09575");
-            Assert.AreEqual(Uri.UnescapeDataString(((ResourceGroupResourceIdentifier)subject.Parent).ResourceGroupName), "myRg");
-            Assert.AreEqual(subject.Parent.ResourceType.Namespace, "Microsoft.Network");
-            Assert.AreEqual(subject.Parent.ResourceType.Type, "virtualNetworks");
-            Assert.AreEqual(Uri.UnescapeDataString(subject.Parent.Name), parentName);
+            Assert.AreEqual(parentResource, subject.Parent);
+            Assert.AreEqual(parentResource.ToString(), subject.Parent.ToString());
+            Assert.AreEqual("0c2f6471-1bf0-4dda-aec3-cb9272f09575", ((ResourceGroupResourceIdentifier)subject.Parent).SubscriptionId);
+            Assert.AreEqual("myRg", Uri.UnescapeDataString(((ResourceGroupResourceIdentifier)subject.Parent).ResourceGroupName));
+            Assert.AreEqual("Microsoft.Network", subject.Parent.ResourceType.Namespace);
+            Assert.AreEqual("virtualNetworks", subject.Parent.ResourceType.Type);
+            Assert.AreEqual(parentName, Uri.UnescapeDataString(subject.Parent.Name));
         }
 
         [TestCase("UnformattedString", Description = "Too Few Elements")]
@@ -214,7 +214,7 @@ namespace Azure.ResourceManager.Core.Tests
         public void CanParseValidLocationResource(string resourceId)
         {
             var id = ConvertToResourceId(resourceId);
-            Assert.AreEqual(id.ToString(), resourceId);
+            Assert.AreEqual(resourceId, id.ToString());
         }
 
         [TestCase("/subscriptions/17fecd63-33d8-4e43-ac6f-0aafa111b38d/providers/Contoso.Widgets/widgets/myWidget/configuration", Description = "singleton homed in a subscription resource")]
@@ -223,7 +223,7 @@ namespace Azure.ResourceManager.Core.Tests
         public void CanParseValidSubscriptionResource(string resourceId)
         {
             SubscriptionResourceIdentifier subscription = resourceId;
-            Assert.AreEqual(resourceId.ToString(), resourceId);
+            Assert.AreEqual(resourceId, subscription.ToString());
         }
 
         [TestCase("/providers/Contoso.Widgets/widgets/myWidget/configuration", Description = "singleton homed in a tenant resource")]
@@ -232,7 +232,7 @@ namespace Azure.ResourceManager.Core.Tests
         public void CanParseValidTenantResource(string resourceId)
         {
             TenantResourceIdentifier tenant = resourceId;
-            Assert.AreEqual(resourceId.ToString(), resourceId);
+            Assert.AreEqual(resourceId, tenant.ToString());
         }
 
         public ResourceIdentifier ConvertToResourceId(string resourceId)
@@ -397,7 +397,7 @@ namespace Azure.ResourceManager.Core.Tests
         public void ResourceIdRetainsOriginalInput(string resourceId)
         {
             ResourceIdentifier id = resourceId;
-            Assert.AreEqual(id.ToString(), resourceId);
+            Assert.AreEqual(resourceId, id.ToString());
         }
 
         [Test]


### PR DESCRIPTION
… resource type expectation

# All SDK Contribution checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] **Please open PR in `Draft` mode if it is:**
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/dotnet/corefx/blob/master/Documentation/coding-guidelines/breaking-change-rules.md).**

### [General Guidelines and Best Practices](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code. (Track 2 only)
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK. Please double check nuget.org current release version.

## Additional management plane SDK specific contribution checklist: 
Note: Only applies to `Microsoft.Azure.Management.[RP]` or `Azure.ResourceManager.[RP]`
 
- [ ] Include updated [management metadata](https://github.com/Azure/azure-sdk-for-net/tree/master/eng/mgmt/mgmtmetadata).
- [ ] Update AzureRP.props to add/remove version info to maintain up to date API versions.

### Management plane SDK Troubleshooting
- If this is very first SDK for a services and you are adding new service folders directly under /SDK, please add `new service` label and/or contact assigned reviewer.
- If the check fails at the `Verify Code Generation` step, please ensure:
	- Do not modify any code in generated folders.
	- Do not selectively include/remove generated files in the PR.
	- Do use `generate.ps1/cmd` to generate this PR instead of calling `autorest` directly.
	Please pay attention to the @microsoft.csharp version output after running `generate.ps1`. If it is lower than current released version (2.3.82), please run it again as it should pull down the latest version.
	
	**Note: We have recently updated the PSH module called by `generate.ps1` to emit additional data. This would help reduce/eliminate the Code Verification check error. Please run following command**:

	    `dotnet msbuild eng/mgmt.proj /t:Util /p:UtilityName=InstallPsModules`

### Old outstanding PR cleanup
 Please note:
	If PRs (including draft) has been out for more than 60 days and there are no responses from our query or followups, they will be closed to maintain a concise list for our reviewers.
